### PR TITLE
Low memory mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,7 @@
-Example cmd to run the script:
+### What's Frigate?
 
-```bash
-PYTHONPATH=. python scripts/alert-stats.py --feature='candidate.magpsf,candidate.sigmapsf' --programids=1,2 --plot=True --start=2460355.5 --nb_days=1 --sp_token=<your_sp_token> --sp_groupIDs=41 --sp_filterIDs=1 --nb_bins=1000 --k_token=<your_kowalski_token>
-```
-
-This would:
-
-- grab magpsf and sigmapsf values of all alerts from one night starting at jd=2460355.5
-- get these values for the subset of alerts that passed the alert filter from group 41 and filter 1 on SkyPortal/Fritz
-- get these values for the subset of alerts that passed the alert filter AND were saved as sources (at anytime, not necessarily during that night).
-- plot histograms for each feature and alert subset (red: all, blue: passed filter, green: saved as sources)
-- plot corner plots for each feature and alert subset (same color palette)
-
-#### V2 (WIP)
-
-- [] Fetch all the features of all alert packets within a given time range with given program ids and store it as a pandas dataframe
-- [] Fetch all of the candidates that passed filters in Fritz (with exact candid, not just objectIds). Relies on the new /api/candidates_filter endpoint.
-- [] Looking at the subset of alerts that passed the filters, find the obj_id of the sources that were saved in Fritz.
-- [] Update the dataframe with a column containing the list of filters passed for each alert, and a column containing the groupIDs for each alert which obj has been saved as a source to the groups associated to the filters passed.
-- [] Figure out what visualizations tools and plots we can use to represent the data in a meaningful way and extract insights from it.
+Frigate is a tool to retrieve and analyze alert data from the ZTF alert stream, from the full set of alerts to the subset of alerts that passed filters in Fritz, and the subset that was saved as proper astronomical sources.
+The current `frigate/__main__.py` only addresses step 1 (getting the full set of alerts for a specified time period, usually one night). The script found in `scripts/alert-stats.py` is an earlier attempt at step 1,2, and 3 along with visualization. Next, we plan to integrate better versions of step 2 and 3 in the `frigate/__main__.py` script and add more visualization tools.
 
 You can run frigate with:
 
@@ -31,3 +14,15 @@ To get the list of all possible arguments, you can run:
 ```bash
 PYTHONPATH=. python frigate --help
 ```
+
+To run the deprecated `scripts/alert-stats.py` script, you can run:
+
+```bash
+PYTHONPATH=. python scripts/alert-stats.py --feature='candidate.magpsf,candidate.sigmapsf' --programids=1,2 --plot=True --start=2460355.5 --nb_days=1 --sp_token=<your_sp_token> --sp_groupIDs=41 --sp_filterIDs=1 --nb_bins=1000 --k_token=<your_kowalski_token>
+```
+
+- [] Fetch all the features of all alert packets within a given time range with given program ids and store it as a pandas dataframe
+- [] Fetch all of the candidates that passed filters in Fritz (with exact candid, not just objectIds). Relies on the new /api/candidates_filter endpoint.
+- [] Looking at the subset of alerts that passed the filters, find the obj_id of the sources that were saved in Fritz.
+- [] Update the dataframe with a column containing the list of filters passed for each alert, and a column containing the groupIDs for each alert which obj has been saved as a source to the groups associated to the filters passed.
+- [] Figure out what visualizations tools and plots we can use to represent the data in a meaningful way and extract insights from it.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ PYTHONPATH=. python scripts/alert-stats.py --feature='candidate.magpsf,candidate
 
 #### Troubleshooting
 
-On a system with low memory, you can call frigate with the `--low_memory` flag to reduce memory usage. This will save each subset of alerts to disk, and concatenate them at the end instead of concatenating as the batched queries return. That way we avoid growing the memory of the main process while the individual threads are running. In the future, we want to expand on that mode to reduce the nb of alerts fetched per batch query to reduce the memory usage even more.
+On a system with low memory, you can call frigate with the `--low_memory=True` flag to reduce memory usage. This will save each subset of alerts to disk, and concatenate them at the end instead of concatenating as the batched queries return. That way we avoid growing the memory of the main process while the individual threads are running. In the future, we want to expand on that mode to reduce the nb of alerts fetched per batch query to reduce the memory usage even more.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ PYTHONPATH=. python scripts/alert-stats.py --feature='candidate.magpsf,candidate
 - [] Looking at the subset of alerts that passed the filters, find the obj_id of the sources that were saved in Fritz.
 - [] Update the dataframe with a column containing the list of filters passed for each alert, and a column containing the groupIDs for each alert which obj has been saved as a source to the groups associated to the filters passed.
 - [] Figure out what visualizations tools and plots we can use to represent the data in a meaningful way and extract insights from it.
+
+#### Troubleshooting
+
+On a system with low memory, you can call frigate with the `--low_memory` flag to reduce memory usage. This will save each subset of alerts to disk, and concatenate them at the end instead of concatenating as the batched queries return. That way we avoid growing the memory of the main process while the individual threads are running. In the future, we want to expand on that mode to reduce the nb of alerts fetched per batch query to reduce the memory usage even more.

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -19,7 +19,13 @@ if __name__ == "__main__":
 
     # GET CANDIDATES FROM KOWALSKI
     candidates, err = get_candidates_from_kowalski(
-        args.start, args.end, args.programids, n_threads=args.n_threads
+        args.start,
+        args.end,
+        args.programids,
+        n_threads=args.n_threads,
+        low_memory=args.low_memory,
+        low_memory_format=args.output_format,
+        low_memory_dir=args.output_directory,
     )
     if err:
         print(err)

--- a/frigate/utils/datasets.py
+++ b/frigate/utils/datasets.py
@@ -72,3 +72,34 @@ def save_dataframe(df, filename, output_format, output_compression, output_compr
 
     # return the filename that includes the output dir and the extension
     return filename
+def load_dataframe(filename, format=None, directory=None):
+    if directory is not None and not filename.startswith(directory):
+        filename = os.path.join(directory, filename)
+
+
+    if format is None:
+        # try to infer the output format from the filename
+        if filename.endswith(".parquet"):
+            format = "parquet"
+        elif filename.endswith(".feather"):
+            format = "feather"
+        elif filename.endswith(".csv"):
+            format = "csv"
+        else:
+            raise ValueError(f"Could not infer output format from filename: {filename}")
+    if format == "parquet":
+        return pd.read_parquet(filename)
+    elif format == "feather":
+        return pd.read_feather(filename)
+    elif format == "csv":
+        return pd.read_csv(filename)
+    else:
+        raise ValueError(f"Invalid output format: {format}, must be one of ['parquet', 'feather', 'csv']")
+
+def remove_file(filename, directory=None):
+    if directory is not None and not filename.startswith(directory):
+        filename = os.path.join(directory, filename)
+    try:
+        os.remove(filename)
+    except Exception as e:
+        raise ValueError(f"Failed to remove file: {e}")

--- a/frigate/utils/parsers.py
+++ b/frigate/utils/parsers.py
@@ -64,6 +64,12 @@ def main_parser():
         default="./data",
         help="Output directory for the results",
     )
+    parser.add_argument(
+        "--low_memory",
+        type=str_to_bool,
+        default=False,
+        help="Use low memory mode, to reduce RAM usage",
+    )
     return parser
 
 


### PR DESCRIPTION
On a system with low memory, you can call noew frigate with the `--low_memory=True` flag to reduce memory usage. 

This will save each subset of alerts to disk, and concatenate them at the end instead of concatenating as the batched queries return. That way we avoid growing the memory of the main process while the individual threads are running. 

In the future, we want to expand on that mode to reduce the nb of alerts fetched per batch query to reduce the memory usage even more.
